### PR TITLE
   vbios_disk: set MTD_RFLAGS when enabling interrupts

### DIFF
--- a/executor/vbios_disk.cc
+++ b/executor/vbios_disk.cc
@@ -304,6 +304,7 @@ public:
 
 	// make sure we are interruptible
 	msg.cpu->efl |= 0x200;
+	msg.mtr_out |= MTD_RFLAGS;
 	return jmp_int(msg, 0x76);
       }
       msg.cpu->ah = read_bda<unsigned char>(DISK_COMPLETION_CODE);


### PR DESCRIPTION
Enabling interrupts without setting the RFLAGS MTD flag causes "VM-entry failure due to invalid guest state." (33) exits on VMX, as the VMM attempts to inject an interrupt into a vCPU that has interrupts disabled.

Setting the MTD_RFLAGS in mtr_out fixes the problem.